### PR TITLE
Test on Julia 1.0 and Julia LTS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,28 +42,21 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install POT
         run: |
           using PyCall: Conda
           Conda.add("pot"; channel="conda-forge")
+
+          # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library
+          open(ENV["GITHUB_ENV"], "a") do io
+            println(io, "LD_PRELOAD=", joinpath(Conda.ROOTENV, "lib", "libstdc++.so.6"))
+          end
         shell: julia --project=. --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: ${{ matrix.coverage || false }}
-        env:
-          # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library
-          LD_PRELOAD: $HOME/.julia/conda/3/lib/libstdc++.so.6
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.coverage
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,8 +53,10 @@ jobs:
           Conda.add("pot"; channel="conda-forge")
 
           # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library
-          open(ENV["GITHUB_ENV"], "a") do io
-            println(io, "LD_PRELOAD=", joinpath(Conda.ROOTENV, "lib", "libstdc++.so.6"))
+          if !Sys.iswindows()
+            open(ENV["GITHUB_ENV"], "a") do io
+              println(io, "LD_PRELOAD=", joinpath(Conda.ROOTENV, "lib", "libstdc++.so.6"))
+            end
           end
         shell: julia --project=. --color=yes {0}
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
+          - windows-latest
         arch:
           - x64
         include:
@@ -55,7 +56,7 @@ jobs:
       - name: Install POT
         run: |
           using PyCall: Conda
-          Conda.add("pot"; channel="conda-forge")
+          Conda.add("pot")
         shell: julia --project=. --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,8 +61,6 @@ jobs:
         with:
           coverage: ${{ matrix.coverage || false }}
         env:
-          # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library
-          LD_PRELOAD: '$HOME/.julia/conda/3/lib/libstdc++.so.6'
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.coverage
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,12 +56,14 @@ jobs:
       - name: Install POT
         run: |
           using PyCall: Conda
-          Conda.add("pot")
+          Conda.add("pot"; channel="conda-forge")
         shell: julia --project=. --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: ${{ matrix.coverage || false }}
         env:
+          # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library
+          LD_PRELOAD: '$HOME/.julia/conda/3/lib/libstdc++.so.6'
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.coverage
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,11 +31,11 @@ jobs:
           - windows-latest
         arch:
           - x64
-        include:
-          - version: '1'
-            os: ubuntu-latest
+        exclude:
+          # Conda installation fails: https://github.com/JuliaPy/Conda.jl/issues/230
+          - version: '1.0'
+            os: windows-latest
             arch: x64
-            coverage: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -44,7 +44,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
         with:
-          cache-packages: "false" # Weird interaction with PyCall settings
+          cache-packages: "false" # Weird interaction with PyCall settings?
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install POT
         run: |
@@ -60,16 +60,22 @@ jobs:
           end
         shell: julia --project=. --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: ${{ matrix.coverage || false }}
       - uses: julia-actions/julia-processcoverage@v1
-        if: matrix.coverage
       - uses: codecov/codecov-action@v2
-        if: matrix.coverage
         with:
-          file: lcov.info
+          files: lcov.info
       - uses: coverallsapp/github-action@master
-        if: matrix.coverage
         with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            path-to-lcov: ./lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info
+          flag-name: run-${{ matrix.version }}
+          parallel: true
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,10 +14,10 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ (matrix.python && 'system Python') || 'conda' }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     env:
-      PYTHON: '' # always use Conda.jl, even on Linux when `python`/`python3` is in the PATH
+      PYTHON: '' # always use Conda.jl, even on Linux where `python`/`python3` is in the PATH
     strategy:
       fail-fast: false
       matrix:
@@ -43,10 +43,13 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+        with:
+          cache-packages: "false" # Weird interaction with PyCall settings
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install POT
         run: |
           using PyCall: Conda
+          Conda.add("nomkl") # Work around https://github.com/JuliaPy/PyPlot.jl/issues/315
           Conda.add("pot"; channel="conda-forge")
 
           # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ (matrix.python && 'system Python') || 'conda' }}
     runs-on: ${{ matrix.os }}
     env:
-      # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library
-      LD_PRELOAD: '$HOME/.julia/conda/3/lib/libstdc++.so.6'
+      PYTHON: '' # always use Conda.jl, even on Linux when `python`/`python3` is in the PATH
     strategy:
       fail-fast: false
       matrix:
@@ -54,13 +53,17 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
-        env:
-          PYTHON: ''
+      - name: Install POT
+        run: |
+          using Conda
+          Conda.add("pot")
+        shell: julia --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: ${{ matrix.coverage || false }}
         env:
-          PYTHON: ''
+          # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library
+          LD_PRELOAD: '$HOME/.julia/conda/3/lib/libstdc++.so.6'
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.coverage
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,6 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
         arch:
           - x64
         include:
@@ -56,7 +55,7 @@ jobs:
       - name: Install POT
         run: |
           using PyCall: Conda
-          Conda.add("pot")
+          Conda.add("pot"; channel="conda-forge")
         shell: julia --project=. --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
           coverage: ${{ matrix.coverage || false }}
         env:
           # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library
-          LD_PRELOAD: '$HOME/.julia/conda/3/lib/libstdc++.so.6'
+          LD_PRELOAD: $HOME/.julia/conda/3/lib/libstdc++.so.6
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.coverage
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,9 +55,9 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install POT
         run: |
-          using Conda
+          using PyCall: Conda
           Conda.add("pot")
-        shell: julia --color=yes {0}
+        shell: julia --project=. --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: ${{ matrix.coverage || false }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,9 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ (matrix.python && 'system Python') || 'conda' }}
     runs-on: ${{ matrix.os }}
+    env:
+      # Workaround for https://github.com/JuliaPy/PyCall.jl/issues/999: Use conda's version of the library
+      LD_PRELOAD: '$HOME/.julia/conda/3/lib/libstdc++.so.6'
     strategy:
       fail-fast: false
       matrix:
@@ -29,9 +32,6 @@ jobs:
           - windows-latest
         arch:
           - x64
-        python:
-          - ''
-          - python
         include:
           - version: '1'
             os: ubuntu-latest
@@ -39,14 +39,6 @@ jobs:
             coverage: true
     steps:
       - uses: actions/checkout@v2
-      - name: Install python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-          architecture: ${{ matrix.arch }}
-        if: matrix.python
-      - run: python -m pip install pot
-        if: matrix.python
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
@@ -63,12 +55,12 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
         env:
-          PYTHON: ${{ matrix.python }}
+          PYTHON: ''
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: ${{ matrix.coverage || false }}
         env:
-          PYTHON: ${{ matrix.python }}
+          PYTHON: ''
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.coverage
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
+          - '1.0'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,8 @@ PyCall = "1"
 julia = "1"
 
 [extras]
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Pkg"]
+test = ["Conda", "Pkg"]


### PR DESCRIPTION
We should test at least the oldest Julia version that we claim to support as well. I have seen in many projects how easy it is to accidentally introduce changes that break compatibility with older versions such as Julia 1.0. IMO it's fine to introduce them and drop support for e.g. Julia < 1.6 (I think generally one should aim for supporting at least Julia LTS) but if we don't run the tests we won't notice these incompatibilities.

Additionally, the PR removes tests with '1.8' since that is (currently) the same as '1' anyway ('1' points to the latest stable Julia release which is 1.8 at the moment). Instead I propose testing the LTS version as well, i.e., (currently) Julia 1.6.